### PR TITLE
Do not filter when all records are requested

### DIFF
--- a/src/DnsRecords.php
+++ b/src/DnsRecords.php
@@ -10,6 +10,7 @@ use BlueLibraries\Dns\Records\DnsUtils;
 use BlueLibraries\Dns\Records\RecordException;
 use BlueLibraries\Dns\Records\RecordFactory;
 use BlueLibraries\Dns\Records\RecordInterface;
+use BlueLibraries\Dns\Records\RecordTypes;
 
 class DnsRecords
 {
@@ -122,7 +123,7 @@ class DnsRecords
 
         foreach ($recordsData as $recordData) {
             $record = $this->factory->create($recordData, $useExtendedRecords);
-            if ($record->getTypeId() === $typeId) {
+            if ($typeId === RecordTypes::ALL || $record->getTypeId() === $typeId) {
                 $result[] = $record;
             }
         }


### PR DESCRIPTION
When requesting all records like this:

```php
$records = DNS::getRecords('bluelibraries.com', RecordTypes::ALL);
```

None are returned because they are filtered by type. But type `ALL` will never match.