### PR TITLE
Remove implicity nullable

### DIFF
--- a/src/DnsRecords.php
+++ b/src/DnsRecords.php
@@ -20,7 +20,7 @@ class DnsRecords
      * @param DnsHandlerInterface|null $handler
      * @param RecordFactory|null $factory
      */
-    public function __construct(DnsHandlerInterface $handler = null, RecordFactory $factory = null)
+    public function __construct(?DnsHandlerInterface $handler = null, ?RecordFactory $factory = null)
     {
         if (is_null($handler)) {
             $handler = new TCP();

--- a/src/Handlers/Raw/RawDataResponse.php
+++ b/src/Handlers/Raw/RawDataResponse.php
@@ -72,7 +72,7 @@ class RawDataResponse
         return $this->headerData['qdcount'] ?? 0;
     }
 
-    function readResponse(int $count = 1, int $offset = null): string
+    function readResponse(int $count = 1, ?int $offset = null): string
     {
         if (is_null($offset)) {
             $return = substr($this->rawBuffer, $this->responseCounter, $count);

--- a/src/Records/RecordFactory.php
+++ b/src/Records/RecordFactory.php
@@ -28,7 +28,7 @@ class RecordFactory
 
     private ExtendedTxtRecords $extendedTxtRecords;
 
-    public function __construct(ExtendedTxtRecords $extendedTxtRecords = null)
+    public function __construct(?ExtendedTxtRecords $extendedTxtRecords = null)
     {
         if (is_null($extendedTxtRecords)) {
             $extendedTxtRecords = new ExtendedTxtRecords();


### PR DESCRIPTION
I just update my project to PHP8.4 and have this message

 "exception" => ErrorException {
    #message: "Deprecated: BlueLibraries\Dns\Records\RecordFactory::__construct(): Implicitly marking parameter $extendedTxtRecords as nullable is deprecated, the explicit nullable type must be used instead"


Small fix 